### PR TITLE
attempt to fix js versions; revert to self-contained html

### DIFF
--- a/R/synapse_helpers.R
+++ b/R/synapse_helpers.R
@@ -114,8 +114,9 @@ save_chart <- function(parent_id, chart_filename, plot_object, static = FALSE) {
 
     chart_widget <- plotly::as_widget(plot_object)
     htmlwidgets::saveWidget(chart_widget, chart_filename,
-                            selfcontained = FALSE)
-    fixed_chart_filename <- fix_js_assets(chart_filename)
+                            selfcontained = TRUE)
+    # fixed_chart_filename <- fix_js_assets(chart_filename)
+    fixed_chart_filename <- chart_filename
 
     syn_entity <- synStore(File(path = fixed_chart_filename,
                                 parentId = parent_id))
@@ -128,8 +129,9 @@ save_datatable <- function(parent_id, dt_filename, dt_widget) {
         dir.create("html")
     }
     htmlwidgets::saveWidget(dt_widget, dt_filename,
-                            selfcontained = FALSE)
-    fixed_dt_filename <- fix_js_assets(dt_filename)
+                            selfcontained = TRUE)
+    # fixed_dt_filename <- fix_js_assets(dt_filename)
+    fixed_dt_filename <- dt_filename
 
     syn_entity <- synStore(File(path = fixed_dt_filename,
                                 parentId = parent_id))

--- a/R/utils.R
+++ b/R/utils.R
@@ -108,6 +108,23 @@ path_replace_gh <- function(path,
     file.path(gh_base, path_folder)
 }
 
+sanitize_versions <- function(path) {
+    safe_versions <- list(
+        "htmlwidgets" = "htmlwidgets-0.9",
+        "datatables-binding" = "datatables-binding-0.2",
+        "datatables-css" = "datatables-css-0.0.0",
+        "dt-core" = "dt-core-1.10.12"
+    )
+    walk2(safe_versions, names(safe_versions), function(lib_version, lib) {
+        path <<- str_replace(
+            path,
+            stringr::str_c(lib, ".*/"),
+            stringr::str_c(lib_version, "/")
+        )
+    })
+    path
+}
+
 # CDN path replacement
 path_replace_cdn <- function(path,
                              repo = "https://cdn-www.synapse.org",
@@ -117,7 +134,8 @@ path_replace_cdn <- function(path,
         "plotlyjs-1.29.2/plotly-latest.min.js" = "https://cdn.plot.ly/plotly-1.29.2.min.js",
         "jquery-1.11.3/jquery.min.js" = "https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js",
         "font-awesome-4.5.0/css/font-awesome.min.css" = "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css",
-        "bootstrap-3.3.5/css/bootstrap.min.css" = "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"
+        "bootstrap-3.3.5/css/bootstrap.min.css" = "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css",
+        "https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js"
     )
 
     path_root <- str_c(str_split(path, "/")[[1]][1], "/")

--- a/scripts/csbc_pson/consortium_summaries_syn7080714.R
+++ b/scripts/csbc_pson/consortium_summaries_syn7080714.R
@@ -6,7 +6,7 @@ source("R/synapse_helpers.R")
 
 synLogin()
 cache_data <- TRUE
-update_remote <- FALSE
+update_remote <- TRUE
 
 # Config ------------------------------------------------------------------
 
@@ -139,7 +139,7 @@ synproject_key <- "Center Name"
 count_cols <- c("id", "tumorType", "diagnosis")
 
 datafile_counts <- fileview_df %>%
-    summarize_files_by_annotationkey_new(
+    summarize_by_annotationkey(
         annotation_keys = group_keys,
         table_id = master_fileview_id,
         synproject_key = synproject_key,
@@ -221,7 +221,7 @@ list_cols <- "study"
 link_keys <- list(study = "Study")
 
 toolfile_counts <- tool_fileview_df %>%
-    summarize_files_by_annotationkey_new(
+    summarize_by_annotationkey(
         annotation_keys = group_keys,
         table_id = master_tool_fileview_id,
         synproject_key = synproject_key,
@@ -254,7 +254,7 @@ group_keys <- "inputDataType"
 count_cols <- "id"
 
 toolfile_counts <- tool_fileview_df %>%
-    summarize_files_by_annotationkey(
+    summarize_by_annotationkey(
         annotation_keys = group_keys,
         table_id = master_tool_fileview_id,
         count_cols = count_cols
@@ -283,7 +283,7 @@ group_keys <- "outputDataType"
 count_cols <- "id"
 
 toolfile_counts <- tool_fileview_df %>%
-    summarize_files_by_annotationkey(
+    summarize_by_annotationkey(
         annotation_keys = group_keys,
         table_id = master_tool_fileview_id,
         count_cols = count_cols


### PR DESCRIPTION
Paths to hosted JS assets don't work if local R package versions (e.g., `DT`, `htmlwidgets`) don't match. As a short--term fix, using larger, self-contained HTML files for now.