### PR TITLE
Swap out stream graphs for more basic stacked bar charts

### DIFF
--- a/portal-dashboard/ui.R
+++ b/portal-dashboard/ui.R
@@ -56,7 +56,7 @@ dashboardPage(
                         box(
                             title = "Files Added", width = 9, height = 500,
                             status = "warning",
-                            streamgraph::streamgraphOutput("files_per_month")
+                            plotly::plotlyOutput("files_per_month")
                             
                         )
                     )


### PR DESCRIPTION
For **KP Over Time** page, plots from the `streamgraph` look cool, but are harder to read and interact with. `ggplot2`/`plotly` stacked bar charts present the same information just as well — especially if there isn't any extra smoothing.