### PR TITLE
Put non-standalone examples in \dontrun{}

### DIFF
--- a/R/charts.R
+++ b/R/charts.R
@@ -18,11 +18,13 @@ custom_theme_bw <- function() {
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' plot_keys <- list(assay = "Assay", tumorType = "Tumor Type",
 #'                   diagnosis = "Diagnosis", species = "Species",
 #'                   organ = "Organ", tissue = "Tissue",
 #'                   dataType = "Data Type", study = "Study")
 #' plot_file_counts_by_annotationkey(fileview_df, plot_keys)
+#' }
 plot_file_counts_by_annotationkey <- function(
     view_df, annotation_keys, replace_missing = "Not Annotated",
     chart_height = NULL
@@ -83,8 +85,10 @@ plot_file_counts_by_annotationkey <- function(
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' plot_keys <- list(assay = "Assay", tumorType = "Tumor Type")
 #' plot_sample_counts_by_annotationkey_2d(fileview_df, "cellLine", plot_keys)
+#' }
 plot_sample_counts_by_annotationkey_2d <- function(
     view_df, sample_key = c("individualID", "specimenID", "cellLine"),
     annotation_keys, filter_missing = TRUE

--- a/R/processing.R
+++ b/R/processing.R
@@ -171,9 +171,11 @@ list_values <- function(
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' test_df %>%
 #'     rowwise() %>%
 #'     mutate(query = build_tablequery(table_id, assay))
+#' }
 build_tablequery <- function(table_id, ...) {
     query_template <- "SELECT * FROM {id} WHERE ( {filters} )"
     dots <- substitute(list(...))[-1]

--- a/R/tables.R
+++ b/R/tables.R
@@ -73,6 +73,7 @@ as_datatable <- function(df, cols_as_code = c()) {
 #' @export
 #'
 #' @examples
+#' \dontrun{
 #' group_keys <- c("assay", "tumorType")
 #' list_cols <- "study"
 #' augment_keys <- list(study = "Center Name")
@@ -86,6 +87,7 @@ as_datatable <- function(df, cols_as_code = c()) {
 #'        augment_keys = augment_keys,
 #'        link_keys = link_keys
 #'    )
+#' }
 summarize_by_annotationkey <- function(
     view_df, annotation_keys, table_id, synproject_key = NULL,
     count_cols = NULL, list_cols = NULL, augment_keys = NULL, link_keys = NULL,

--- a/man/build_tablequery.Rd
+++ b/man/build_tablequery.Rd
@@ -15,7 +15,9 @@ Construct a Synapse SQL-style table query using names/values of data frame
 column(s) to compose 'WHERE' clauses
 }
 \examples{
+\dontrun{
 test_df \%>\%
     rowwise() \%>\%
     mutate(query = build_tablequery(table_id, assay))
+}
 }

--- a/man/plot_file_counts_by_annotationkey.Rd
+++ b/man/plot_file_counts_by_annotationkey.Rd
@@ -18,9 +18,11 @@ Plot the breakdown of files from a file view according to distinct values
 within each specified annotation key (i.e., category).
 }
 \examples{
+\dontrun{
 plot_keys <- list(assay = "Assay", tumorType = "Tumor Type",
                   diagnosis = "Diagnosis", species = "Species",
                   organ = "Organ", tissue = "Tissue",
                   dataType = "Data Type", study = "Study")
 plot_file_counts_by_annotationkey(fileview_df, plot_keys)
+}
 }

--- a/man/plot_sample_counts_by_annotationkey_2d.Rd
+++ b/man/plot_sample_counts_by_annotationkey_2d.Rd
@@ -18,6 +18,8 @@ Plot the breakdown of samples in a file view based on distinct values
 within two specified annotation keys.
 }
 \examples{
+\dontrun{
 plot_keys <- list(assay = "Assay", tumorType = "Tumor Type")
 plot_sample_counts_by_annotationkey_2d(fileview_df, "cellLine", plot_keys)
+}
 }

--- a/man/summarize_by_annotationkey.Rd
+++ b/man/summarize_by_annotationkey.Rd
@@ -35,6 +35,7 @@ construct links from Synapse IDs in corresponding ID columns (list values)}
 Count files in a Synapse file view, grouped by annotation keys.
 }
 \examples{
+\dontrun{
 group_keys <- c("assay", "tumorType")
 list_cols <- "study"
 augment_keys <- list(study = "Center Name")
@@ -48,4 +49,5 @@ fileview_df \%>\%
        augment_keys = augment_keys,
        link_keys = link_keys
    )
+}
 }


### PR DESCRIPTION
These examples use datasets (`test_df`, `fileview_df`) that aren't defined within the example, causing R CMD check errors. This PR wraps the examples in `\dontrun{}` so they remain in the docs but R CMD Check doesn't attempt to run them.