### PR TITLE
Create testdata dir in setup.R

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -22,6 +22,7 @@ mock_fileview_df <- tibble(
 # paths to mocked files
 mock_chart_filename <- "mock_chart.html"
 mock_datatable_filename <- "mock_datatable.html"
+dir_create("testdata")
 
 # create and save mock chart
 plot_keys <- list(data_annotation = "Assay", status_annotation = "Disease")


### PR DESCRIPTION
After #78 the `testdata/` dir is removed completely, which causes problems when `setup.R` tries to write to it. This makes sure that the `testdata/` dir is created within `setup.R`.