### PR TITLE
Update setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="synapse-dcc-utility-scripts",
+    name="syndccutils",
     packages=find_packages(),
     license='Apache License, Version 2.0',
-    version='1.0.0',
+    version='1.1.0',
     install_requires=[
         'pandas',
         'synapseclient'],


### PR DESCRIPTION
change package name - impetus was to allow pip install through github which choked on the difference between the package folder name and the name in here.  

Made minor version bump, b/c I don't know if this is a breaking change. Seems like it might be given the above.