### PR TITLE
Fix namespace bug in add_fileview_annotations

### DIFF
--- a/R/R/add_fileview_annotations.R
+++ b/R/R/add_fileview_annotations.R
@@ -29,7 +29,8 @@
 add_fileview_annotations <- function(data, fileview_id) {
   schema <- synapser::synGet(fileview_id)
   fileview <- synapser::synTableQuery(paste0("SELECT * FROM ", fileview_id))
-  cols_to_add <- names(data)[!names(data) %in% names(as.data.frame(fileview))]
+  fileview_df <- synapser::as.data.frame(fileview)
+  cols_to_add <- names(data)[!names(data) %in% names(fileview_df)]
   purrr::walk(cols_to_add, function(x) {
     schema$addColumn(
       synapser::Column(


### PR DESCRIPTION
Needed to reference the synapser namespace for the `as.data.frame()` method. I've split this into two lines for readability.