### PR TITLE
Set env var to not throw error about remotes warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ matrix:
     before_install:
     - cd R
 
+env:
+  global:
+    - R_REMOTES_NO_ERRORS_FROM_WARNINGS=true


### PR DESCRIPTION
This should fix the travis errors we've been seeing.