### PR TITLE
Update GEO script

### DIFF
--- a/R/scripts/get-geo-annotations.R
+++ b/R/scripts/get-geo-annotations.R
@@ -86,9 +86,8 @@ if(any(metadata.tbl$type == "SRA")) {
   for(i in 1:nrow(metadata.tbl)) {
     if(metadata.tbl$type[i] == "SRA") {
       ## Extract the SRA identifier
-      ## NB: this is probably also in the relation column
-      url <- metadata.tbl$url[i]
-      sra.identifier <- gsub("^.*\\/([^\\/]+)$", "\\1", url)
+      relation <- metadata.tbl$relation[i]
+      sra.identifier <- gsub("^(.+?)sra\\?term=(.+)$", "\\2", relation)
       url <- listSRAfile(sra.identifier, con)$ftp
       metadata.tbl$url[i] <- url
     }

--- a/R/scripts/get-geo-annotations.R
+++ b/R/scripts/get-geo-annotations.R
@@ -12,6 +12,8 @@ suppressPackageStartupMessages(p_load("GEOquery"))
 suppressPackageStartupMessages(p_load("SRAdb"))
 suppressPackageStartupMessages(p_load("plyr"))
 suppressPackageStartupMessages(p_load("optparse"))
+suppressPackageStartupMessages(p_load("xml2"))
+suppressPackageStartupMessages(p_load("rentrez"))
 
 option_list <- list(
                     make_option(c("--gse"), action="store",
@@ -76,6 +78,28 @@ if(length(supp.file.columns) > 1) {
 
 metadata.tbl$url <- as.character(metadata.tbl[, supp.file.columns[1]])
 
+## Function to find FTP link by searching Entrez and parsing the XML results
+get_link_from_entrez <- function(sra) {
+  search_results <- entrez_search(db = "sra", term = paste0(sra, "[Accession]"))
+  if (length(search_results$ids) > 1) {
+    stop("Too many ids found", call. = FALSE)
+  }
+  ## Fetch entity via entrez
+  entity <- entrez_fetch(db = "sra", id = search_results$id, rettype = "xml")
+
+  ## Parse XML and find the id that corresponds to the SRA file (this is
+  ## different than the SRA id)
+  entity_xml <- read_xml(entity)
+  id <- xml_text(xml_find_first(entity_xml, "//RUN_SET/RUN/IDENTIFIERS"))
+
+  ## Build path to FTP
+  base_path <- "ftp://ftp-trace.ncbi.nih.gov/sra/sra-instant/reads/ByRun/sra"
+  first3 <- substr(id, 1, 3)
+  first6 <- substr(id, 1, 6)
+  ftp <- paste(base_path, first3, first6, id, paste0(id, ".sra"), sep = "/")
+  ftp
+}
+
 if(any(metadata.tbl$type == "SRA")) {
   sra.db.dest.file <- "SRAmetadb.sqlite"
   if(!file.exists(sra.db.dest.file)) {
@@ -88,7 +112,17 @@ if(any(metadata.tbl$type == "SRA")) {
       ## Extract the SRA identifier
       relation <- metadata.tbl$relation[i]
       sra.identifier <- gsub("^(.+?)sra\\?term=(.+)$", "\\2", relation)
-      url <- listSRAfile(sra.identifier, con)$ftp
+      ## Find FTP link in one of two ways: 1) look up in the SRA database. 2) if
+      ## not found (e.g. because database isn't up to date), search using Entrez
+      url <- try(listSRAfile(sra.identifier, con)$ftp, silent = TRUE)
+      if (inherits(url, "try-error")) {
+        message("Could not find SRA file in SRA database; searching Entrez instead.")
+        url <- try(get_link_from_entrez(sra.identifier), silent = TRUE)
+      }
+      if (inherits(url, "try-error")) {
+        warning("Could not find FTP link to SRA file", call. = FALSE)
+        url <- NA
+      }
       metadata.tbl$url[i] <- url
     }
   }

--- a/R/scripts/get-geo-annotations.R
+++ b/R/scripts/get-geo-annotations.R
@@ -132,11 +132,14 @@ get_link <- function(sra) {
   return(url)
 }
 
+## Look up FTP links for SRA files in metadata.tbl and add to url column
 if (any(metadata.tbl$type == "SRA")) {
   for (i in seq_len(nrow(metadata.tbl))) {
     if (metadata.tbl$type[i] == "SRA") {
       relation <- metadata.tbl$relation[i]
+      ## Extract SRA id
       sra.identifier <- gsub("^(.+?)sra\\?term=(.+)$", "\\2", relation)
+      ## Get FTP link
       metadata.tbl$url[i] <- get_link(sra.identifier)
     }
   }

--- a/R/scripts/get-geo-annotations.R
+++ b/R/scripts/get-geo-annotations.R
@@ -1,5 +1,13 @@
 #!/usr/bin/env Rscript
 
+##########################################################
+####  Access metadata from GEO and export as a table  ####
+##########################################################
+
+## Sample usage:
+## $ Rscript get-geo-annotations.R --gse "GSE89777" > manifest.tsv
+
+## Load packages
 usePackage <- function(p) 
 {
   if (!is.element(p, installed.packages()[,1]))
@@ -103,6 +111,8 @@ get_link_from_entrez <- function(sra) {
 if(any(metadata.tbl$type == "SRA")) {
   sra.db.dest.file <- "SRAmetadb.sqlite"
   if(!file.exists(sra.db.dest.file)) {
+    ## Download SRA database file. Note this is large (~35 GB as of 2018-12-19)
+    ## so will take some time
     sra.db.dest.file <- getSRAdbFile(destfile = paste0(sra.db.dest.file, ".gz"))
   }
   con <- dbConnect(RSQLite::SQLite(), sra.db.dest.file)

--- a/R/scripts/get-geo-annotations.R
+++ b/R/scripts/get-geo-annotations.R
@@ -60,7 +60,7 @@ metadata.tbl <- ldply(sampleNames(phenoData(gse.geo[[1]])),
                         
                         ## Metadata is a list of lists.
                         ## Go through each entry and concatenate the individual lists using a ';' delimiter
-                        as.data.frame(lapply(md, function(entry) paste(entry, collapse=";")))
+                        as.data.frame(lapply(md, function(entry) paste(entry, collapse=";")), stringsAsFactors = FALSE)
                       })
 
 ## If these are SRA entries, the entity listed in supplementary_file will be a directory


### PR DESCRIPTION
I've made a few updates to the `get-geo-annotations.R` script. The two main changes are: 
1) I extract the SRA term from the "relation" column, not the url column (the latter didn't work for me as written); @bswhite I think you had made a similar change in your local version as well.
2) I've added a second method for looking up the FTP link for an SRA file. It appears there is a delay between when files are shared on GEO and when they appear in the SRA database, so the original method which looks up the files in the database wasn't working for me. The second option is to search Entrez for the identifier and build the FTP path (which follows a common pattern) using that id. In this PR the script tries the database first, and only searches Entrez if it doesn't find the file in the database. We could opt to use Entrez exclusively, thus saving users from having to download the 35 GB database file, but I really have no idea how robust the structure of the Entrez results is, so I'm a little hesitant to do that without more testing.

@milen-sage @bswhite let me know if these changes look useful to you or if you have any questions.