### PR TITLE
Allow synapser to be installed on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
-sudo: false
+sudo: required
 warnings_are_errors: false
+
+before_install:
+  - sudo apt-get update -y
+  - sudo apt-get install -y dpkg-dev zlib1g-dev libssl-dev libffi-dev
+  - sudo apt-get install -y curl libcurl4-openssl-dev
 
 matrix:
   include:
@@ -12,3 +17,5 @@ matrix:
 env:
   global:
     - R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
+    - PYTHON_CLIENT_GITHUB_USERNAME=kimyen
+    - PYTHON_CLIENT_GITHUB_BRANCH=SYNPY-833


### PR DESCRIPTION
I've been seeing travis failures on recent PRs, I think related to [this jira issue](https://sagebionetworks.jira.com/browse/SYNR-1375). These changes to .travis.yml should hopefully fix the issue until the next versions of the clients are released.