### PR TITLE
Add nonstandard package elements to .Rbuildignore

### DIFF
--- a/R/.Rbuildignore
+++ b/R/.Rbuildignore
@@ -1,2 +1,5 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^codecheck\.R$
+^LICENSE$
+^scripts/


### PR DESCRIPTION
This addresses one of the NOTEs currently thrown by R CMD check