### PR TITLE
Set R version dependency with patch level 0

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person("Sage Bionetworks", role = c("cph"))
     )
 Description: Code for managing data coordinating operations (e.g., development of the CSBC/PS-ON Knowledge Portal and individual Center pages) for Sage-supported communities through Synapse.
-Depends: R (>= 3.4.1)
+Depends: R (>= 3.4.0)
 License: Apache License (>= 2.0)
 Imports:
     dplyr,


### PR DESCRIPTION
This is another small fix to appease R CMD check. Packages should depend on an R version at patch level 0 (e.g. `R (>= 3.4.0)` or `R (>= 3.4)` but not `R (>= 3.4.1)`).