### PR TITLE
Add synID parameter to get_synapse_annotations()

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: syndccutils
 Title: Synapse DCC Utilities for R
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: c(
     person("James", "Eddy", email = "james.eddy@sagebionetworks.org", role = c("aut", "cre")),
     person("Sage Bionetworks", role = c("cph"))
@@ -43,4 +43,4 @@ Remotes:
     ropensci/plotly
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.1

--- a/R/R/annotations.R
+++ b/R/R/annotations.R
@@ -2,7 +2,9 @@
 #'
 #' Download current annotation values from Synapse and provide them as a data
 #' frame.
-#' 
+#'
+#' @param synID. The Synapse ID of a table to query from. Defaults to
+#'   "syn10242922"
 #' @return A data frame containing all annotation keys, descriptions, column
 #'   types, maximum sizes, values, value descriptions, sources, and the name of
 #'   the annotation's parent module.
@@ -13,8 +15,8 @@
 #' synLogin()
 #' dat <- get_synapse_annotations()
 #' }
-get_synapse_annotations <- function() {
-  queryResult <- synapser::synTableQuery('select * from syn10242922')
+get_synapse_annotations <- function(synID = "syn10242922") {
+  queryResult <- synapser::synTableQuery(glue::glue('select * from {synID}'))
   dat <- synapser::as.data.frame(queryResult)
   dat <- dat[, !names(dat) %in% c("ROW_ID", "ROW_VERSION")]
   dat

--- a/R/man/get_synapse_annotations.Rd
+++ b/R/man/get_synapse_annotations.Rd
@@ -4,7 +4,11 @@
 \alias{get_synapse_annotations}
 \title{Get Synapse annotations}
 \usage{
-get_synapse_annotations()
+get_synapse_annotations(synID = "syn10242922")
+}
+\arguments{
+\item{synID.}{The Synapse ID of a table to query from. Defaults to
+"syn10242922"}
 }
 \value{
 A data frame containing all annotation keys, descriptions, column


### PR DESCRIPTION
Allowing the function to return alternate tables of annotation definitions. 